### PR TITLE
Add MIME types to desktop file

### DIFF
--- a/desktop/org.daa.NeovimGtk.desktop
+++ b/desktop/org.daa.NeovimGtk.desktop
@@ -7,3 +7,4 @@ Type=Application
 Terminal=false
 Categories=GTK;Utility;TextEditor;
 StartupNotify=true
+MimeType=text/english;text/plain;text/x-makefile;text/x-c++hdr;text/x-c++src;text/x-chdr;text/x-csrc;text/x-java;text/x-moc;text/x-pascal;text/x-tcl;text/x-tex;application/x-shellscript;text/x-c;text/x-c++;


### PR DESCRIPTION
Copied `MimeType` line from `nvim.desktop` which copied it from `gvim.desktop`.