### PR TITLE
Introduce new-window action, set non_unique

### DIFF
--- a/src/ui.rs
+++ b/src/ui.rs
@@ -8,7 +8,7 @@ use gtk_sys;
 use gtk::prelude::*;
 use gtk::{ApplicationWindow, HeaderBar, ToolButton, Image, AboutDialog, SettingsExt};
 use gio::prelude::*;
-use gio::{Menu, MenuExt, MenuItem, MenuItemExt, SimpleAction};
+use gio::{Menu, MenuExt, MenuItem, SimpleAction};
 
 use settings::Settings;
 use shell::{Shell, ShellOptions};
@@ -194,14 +194,16 @@ impl Ui {
 
         let menu = Menu::new();
 
-        let plugs = MenuItem::new("Plugins", None);
-        plugs.set_detailed_action("app.Plugins");
-        menu.append_item(&plugs);
+        let section = Menu::new();
+        section.append_item(&MenuItem::new("New Window", "app.new-window"));
+        menu.append_section(None, &section);
 
-        let about = MenuItem::new("About", None);
-        about.set_detailed_action("app.HelpAbout");
-        menu.append_item(&about);
+        let section = Menu::new();
+        section.append_item(&MenuItem::new("Plugins", "app.Plugins"));
+        section.append_item(&MenuItem::new("About", "app.HelpAbout"));
+        menu.append_section(None, &section);
 
+        menu.freeze();
         app.set_app_menu(Some(&menu));
 
         let plugs_action = SimpleAction::new("Plugins", None);


### PR DESCRIPTION
These are two weakly related changes:

- Set `APPLICATION_NON_UNIQUE`.
  This causes the application to start new instances in their own processes instead of using the primary instance for all windows. I feel this is a more natural behaviour for vim as the instances aren't really related. It also has the advantage, that crashing instances don't crash other instances and that new instances correctly set their current working directory to the one they were started from instead of reusing the cwd of the primary instance.

-  Introduce `new-window` action.
  Add a "New Window" entry to the menu. Also, Gnome checks for this action when [trying to figure out whether the application can open a new window](https://github.com/GNOME/gnome-shell/blob/master/src/shell-app.c#L576-L583). For example the dash-to-dock extension looks at this when the application is middle-clicked and doesn't launch a new instance if `can_open_new_window` returned false.

Update: I just saw https://github.com/daa84/neovim-gtk/issues/19. You mentioned that one could open files in the same window instead of new ones. Is this currently supported, i.e. does my change break with this?