### PR TITLE
Fix popup colors not being reversed

### DIFF
--- a/src/theme.rs
+++ b/src/theme.rs
@@ -57,10 +57,14 @@ fn get_hl_colors(nvim: &mut Neovim, hl: &str) -> (Option<Color>, Option<Color>) 
     nvim.get_hl_by_name(hl, true)
         .ok_and_report()
         .and_then(|m| if let Some(m) = m.to_attrs_map_report() {
-            Some((
-                get_hl_color(&m, "background"),
-                get_hl_color(&m, "foreground"),
-            ))
+            let reverse = m.get("reverse").and_then(|v| v.as_bool()).unwrap_or(false);
+            let bg = get_hl_color(&m, "background");
+            let fg = get_hl_color(&m, "foreground");
+            if reverse {
+                Some((fg, bg))
+            } else {
+                Some((bg, fg))
+            }
         } else {
             None
         })


### PR DESCRIPTION
I use a color scheme ([hybrid](https://github.com/w0ng/vim-hybrid)), where `Pmenu` and `PmenuSel` are identical except `PmenuSel` sets `reverse`. On the popup menu, this causes the selected line to be indistinguishable from the unselected ones.

I don't know if this code makes sense at this place, but it fixes the issue for me.