### PR TITLE
Add RPC/GTK clipboard provider

### DIFF
--- a/runtime/plugin/nvim_gui_shim.vim
+++ b/runtime/plugin/nvim_gui_shim.vim
@@ -4,6 +4,16 @@ if !has('nvim') || exists('g:GuiLoaded')
 endif
 let g:GuiLoaded = 1
 
+if !exists('g:GuiExternalClipboard')
+	function! provider#clipboard#Call(method, args) abort
+		if a:method == 'get'
+			return [rpcrequest(1, 'Gui', 'Clipboard', 'Get'), 'v']
+		elseif a:method == 'set'
+			call rpcnotify(1, 'Gui', 'Clipboard', 'Set', join(a:args[0], ''))
+		endif
+	endfunction
+endif
+
 " Set GUI font
 function! GuiFont(fname, ...) abort
 	call rpcnotify(1, 'Gui', 'Font', s:NvimQtToPangoFont(a:fname))
@@ -42,4 +52,3 @@ function s:GuiFontCommand(fname, bang) abort
 endfunction
 command! -nargs=? -bang Guifont call s:GuiFontCommand("<args>", "<bang>")
 command! -nargs=? -bang GuiFont call s:GuiFontCommand("<args>", "<bang>")
-

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -80,6 +80,7 @@ pub struct State {
     cursor: Option<Cursor>,
     popup_menu: RefCell<PopupMenu>,
     settings: Rc<RefCell<Settings>>,
+    pub clipboard: gtk::Clipboard,
 
     pub mode: mode::Mode,
 
@@ -113,6 +114,7 @@ impl State {
             cursor: None,
             popup_menu,
             settings,
+            clipboard: gtk::Clipboard::get(&gdk::Atom::intern("CLIPBOARD")),
 
             mode: mode::Mode::new(),
 
@@ -199,6 +201,10 @@ impl State {
         if let Some(mut nvim) = self.nvim() {
             nvim.command(&format!("cd {}", path)).report_err();
         }
+    }
+
+    pub fn clipboard_set(&self, text: &str) {
+        self.clipboard.set_text(text);
     }
 
     fn close_popup_menu(&self) {


### PR DESCRIPTION
Hi, just discovered this project recently, ligatures and native completion popups are great, I'm actually looking into switching from tmux + neovim in terminal to this + terminals in neovim :)

To avoid xclip usage on Wayland and to improve potential remote usage, it would be nice to have native gtk clipboard support. Here's my attempt :)

- Can't have the UI borrowed mutably when waiting for the clipboard text, so I had to push the mutex locking down into the request handlers to be able to make the borrows work for the clipboard get command;
- Using an `mpsc` channel basically as a future, to avoid extra dependencies; 
- I've tried placing the clipboard function into `runtime/autoload/providers/clipboard.vim`, but it didn't load for some reason