### PR TITLE
GTK clipboard part 2

### DIFF
--- a/runtime/plugin/nvim_gui_shim.vim
+++ b/runtime/plugin/nvim_gui_shim.vim
@@ -1,15 +1,15 @@
 " A Neovim plugin that implements GUI helper commands
 if !has('nvim') || exists('g:GuiLoaded')
-  finish
+	finish
 endif
 let g:GuiLoaded = 1
 
 if exists('g:GuiInternalClipboard')
 	function! provider#clipboard#Call(method, args) abort
 		if a:method == 'get'
-			return [rpcrequest(1, 'Gui', 'Clipboard', 'Get'), 'v']
+			return [rpcrequest(1, 'Gui', 'Clipboard', 'Get', a:args[0]), 'v']
 		elseif a:method == 'set'
-			call rpcnotify(1, 'Gui', 'Clipboard', 'Set', join(a:args[0], ''))
+			call rpcnotify(1, 'Gui', 'Clipboard', 'Set', a:args[2], join(a:args[0], ''))
 		endif
 	endfunction
 endif

--- a/runtime/plugin/nvim_gui_shim.vim
+++ b/runtime/plugin/nvim_gui_shim.vim
@@ -5,10 +5,12 @@ endif
 let g:GuiLoaded = 1
 
 if exists('g:GuiInternalClipboard')
+	let s:LastRegType = 'v'
 	function! provider#clipboard#Call(method, args) abort
 		if a:method == 'get'
-			return [rpcrequest(1, 'Gui', 'Clipboard', 'Get', a:args[0]), 'v']
+			return [rpcrequest(1, 'Gui', 'Clipboard', 'Get', a:args[0]), s:LastRegType]
 		elseif a:method == 'set'
+			let s:LastRegType = a:args[1]
 			call rpcnotify(1, 'Gui', 'Clipboard', 'Set', a:args[2], join(a:args[0], ''))
 		endif
 	endfunction

--- a/src/nvim/redraw_handler.rs
+++ b/src/nvim/redraw_handler.rs
@@ -117,7 +117,10 @@ pub fn call_gui_event(
         "Clipboard" => {
             match try_str!(args[0]) {
                 "Set" => {
-                    ui.clipboard_set(try_str!(args[1]));
+                    match try_str!(args[1]) {
+                        "*" => ui.clipboard_primary_set(try_str!(args[2])),
+                        _ => ui.clipboard_clipboard_set(try_str!(args[2])),
+                    }
                 },
                 opt => error!("Unknown option {}", opt),
             }
@@ -162,7 +165,10 @@ pub fn call_gui_request(
                     // mutably twice!
                     let clipboard = {
                         let ui = &mut ui.borrow_mut();
-                        ui.clipboard.clone()
+                        match try_str!(args[1]) {
+                            "*" => ui.clipboard_primary.clone(),
+                            _ => ui.clipboard_clipboard.clone(),
+                        }
                     };
                     let t = clipboard.wait_for_text().unwrap_or_else(|| String::new());
                     Ok(Value::Array(t.split("\n").map(|s| s.into()).collect::<Vec<Value>>()))

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -59,7 +59,8 @@ pub struct State {
     cursor: Option<Cursor>,
     popup_menu: RefCell<PopupMenu>,
     settings: Rc<RefCell<Settings>>,
-    pub clipboard: gtk::Clipboard,
+    pub clipboard_clipboard: gtk::Clipboard,
+    pub clipboard_primary: gtk::Clipboard,
 
     pub mode: mode::Mode,
 
@@ -91,7 +92,8 @@ impl State {
             cursor: None,
             popup_menu,
             settings,
-            clipboard: gtk::Clipboard::get(&gdk::Atom::intern("CLIPBOARD")),
+            clipboard_clipboard: gtk::Clipboard::get(&gdk::Atom::intern("CLIPBOARD")),
+            clipboard_primary: gtk::Clipboard::get(&gdk::Atom::intern("PRIMARY")),
 
             mode: mode::Mode::new(),
 
@@ -178,8 +180,12 @@ impl State {
         }
     }
 
-    pub fn clipboard_set(&self, text: &str) {
-        self.clipboard.set_text(text);
+    pub fn clipboard_clipboard_set(&self, text: &str) {
+        self.clipboard_clipboard.set_text(text);
+    }
+
+    pub fn clipboard_primary_set(&self, text: &str) {
+        self.clipboard_primary.set_text(text);
     }
 
     fn close_popup_menu(&self) {


### PR DESCRIPTION
- Added `PRIMARY` support (please test, I'm currenty running Wayland where it's not a thing)
- "Fixed" `yy` line copying (by storing the last register type — this is mostly fine, but e.g. pasting from other apps after copying lines would paste as lines)

Actually, register type should be stored in the GTK clipboard, like in good old GVim. I'm looking into this, including https://github.com/gtk-rs/gtk/issues/591