### PR TITLE
Introduce file browser and some other changes

### DIFF
--- a/resources/menu.ui
+++ b/resources/menu.ui
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<interface>
+  <menu id="hamburger-menu">
+    <section>
+      <attribute name="id">file-section</attribute>
+      <item>
+        <attribute name="label">Paste</attribute>
+        <attribute name="action">win.paste</attribute>
+      </item>
+      <item>
+        <attribute name="label">Save All</attribute>
+        <attribute name="action">win.save-all</attribute>
+      </item>
+    </section>
+  </menu>
+</interface>

--- a/resources/side-panel.ui
+++ b/resources/side-panel.ui
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interface>
+  <object class="GtkMenu" id="file_browser_context_menu">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <child>
+      <object class="GtkMenuItem">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="action_name">filebrowser.reload</property>
+        <property name="label" translatable="yes">Reload</property>
+      </object>
+    </child>
+    <child>
+      <object class="GtkCheckMenuItem" id="file_browser_show_hidden_checkbox">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="label">Show Hidden Files</property>
+      </object>
+    </child>
+  </object>
+  <object class="GtkTreeStore" id="file_browser_tree_store">
+    <columns>
+      <!-- Filename -->
+      <column type="gchararray"/>
+      <!-- Path -->
+      <column type="gchararray"/>
+      <!-- File type -->
+      <column type="guchar"/>
+      <!-- Icon name -->
+      <column type="gchararray"/>
+    </columns>
+  </object>
+  <object class="GtkImage" id="go_up_image">
+    <property name="can_focus">False</property>
+    <property name="icon_name">go-up-symbolic</property>
+  </object>
+  <object class="GtkBox" id="file_browser">
+    <property name="width_request">200</property>
+    <property name="can_focus">False</property>
+    <property name="orientation">vertical</property>
+    <child>
+      <object class="GtkToolbar" id="file_browser_toolbar">
+        <property name="can_focus">False</property>
+        <child>
+          <object class="GtkToolItem">
+            <property name="can_focus">False</property>
+            <property name="margin_right">8</property>
+            <child>
+              <object class="GtkButton" id="file_browser_go_up_button">
+                <property name="can_focus">False</property>
+                <property name="receives_default">False</property>
+                <property name="image">go_up_image</property>
+              </object>
+            </child>
+          </object>
+        </child>
+        <child>
+          <object class="GtkToolItem">
+            <property name="can_focus">False</property>
+            <property name="halign">start</property>
+            <child>
+              <object class="GtkLabel" id="file_browser_current_dir">
+                <property name="can_focus">False</property>
+                <property name="ellipsize">end</property>
+              </object>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">True</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+    <child>
+      <object class="GtkScrolledWindow" id="file_browser_scroll">
+        <property name="expand">True</property>
+        <property name="can_focus">False</property>
+        <child>
+          <object class="GtkTreeView" id="file_browser_tree_view">
+            <property name="can_focus">False</property>
+            <property name="model">file_browser_tree_store</property>
+            <property name="headers_visible">False</property>
+            <property name="activate_on_single_click">True</property>
+            <child>
+              <object class="GtkTreeViewColumn">
+                <child>
+                  <object class="GtkCellRendererPixbuf" id="cell_renderer_icon"/>
+                  <attributes>
+                    <attribute name="icon_name">3</attribute>
+                  </attributes>
+                </child>
+                <child>
+                  <object class="GtkCellRendererText" id="cell_renderer_filename"/>
+                  <attributes>
+                    <attribute name="text">0</attribute>
+                  </attributes>
+                </child>
+              </object>
+            </child>
+          </object>
+        </child>
+      </object>
+    </child>
+  </object>
+</interface>

--- a/src/file_browser.rs
+++ b/src/file_browser.rs
@@ -1,0 +1,390 @@
+use std::cell::RefCell;
+use std::cmp::Ordering;
+use std::io;
+use std::fs;
+use std::fs::DirEntry;
+use std::path::{Path, Component};
+use std::rc::Rc;
+use std::ops::Deref;
+
+use gio;
+use gio::prelude::*;
+use gtk;
+use gtk::{MenuExt};
+use gtk::prelude::*;
+
+use neovim_lib::NeovimApi;
+
+use nvim::{NeovimClient, ErrorReport, NeovimRef};
+use shell;
+
+struct Components {
+    go_up_btn: gtk::Button,
+    cwd_label: gtk::Label,
+    context_menu: gtk::Menu,
+    show_hidden_checkbox: gtk::CheckMenuItem,
+}
+
+struct State {
+    current_dir: String,
+    show_hidden: bool,
+}
+
+
+pub struct FileBrowserWidget {
+    store: gtk::TreeStore,
+    tree: gtk::TreeView,
+    widget: gtk::Box,
+    nvim: Option<Rc<NeovimClient>>,
+    comps: Components,
+    state: Rc<RefCell<State>>,
+}
+
+impl Deref for FileBrowserWidget {
+    type Target = gtk::Box;
+
+    fn deref(&self) -> &gtk::Box {
+        &self.widget
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
+enum FileType {
+    File,
+    Dir,
+}
+
+#[allow(dead_code)]
+enum Column {
+    Filename,
+    Path,
+    FileType,
+    IconName,
+}
+
+impl FileBrowserWidget {
+    pub fn new() -> Self {
+        let builder = gtk::Builder::new_from_string(include_str!("../resources/side-panel.ui"));
+        let widget: gtk::Box = builder.get_object("file_browser").unwrap();
+        let tree: gtk::TreeView = builder.get_object("file_browser_tree_view").unwrap();
+        let store: gtk::TreeStore = builder.get_object("file_browser_tree_store").unwrap();
+        let go_up_btn: gtk::Button = builder.get_object("file_browser_go_up_button").unwrap();
+        let cwd_label: gtk::Label = builder.get_object("file_browser_current_dir").unwrap();
+        let context_menu: gtk::Menu = builder.get_object("file_browser_context_menu").unwrap();
+        let show_hidden_checkbox: gtk::CheckMenuItem =
+            builder.get_object("file_browser_show_hidden_checkbox").unwrap();
+
+        let file_browser = FileBrowserWidget {
+            store,
+            tree,
+            widget,
+            nvim: None,
+            comps: Components {
+                go_up_btn,
+                cwd_label,
+                context_menu,
+                show_hidden_checkbox,
+            },
+            state: Rc::new(RefCell::new(State {
+                current_dir: "".to_owned(),
+                show_hidden: false,
+            })),
+        };
+        file_browser
+    }
+
+    fn nvim(&self) -> Option<NeovimRef> {
+        self.nvim.as_ref().unwrap().nvim()
+    }
+
+    pub fn init(&mut self, shell_state: &shell::State) {
+        // Initialize values.
+        let nvim = shell_state.nvim_clone();
+        self.nvim = Some(nvim);
+        let dir = get_current_dir(&mut self.nvim().unwrap());
+        update_toolbar(&dir, &self.comps.go_up_btn, &self.comps.cwd_label);
+        self.state.borrow_mut().current_dir = dir;
+
+        // Populate tree.
+        tree_reload(&self.store, &self.state.borrow());
+
+        // We cannot recursively populate all directories. Instead, we have prepared a single empty
+        // child entry for all non-empty directories, so the little expand arrow will be shown. Now,
+        // when a directory is expanded, populate its children.
+        let store = self.store.clone();
+        let state_ref = Rc::clone(&self.state);
+        self.tree.connect_test_expand_row(move |_, iter, _| {
+            let state = state_ref.borrow();
+            if let Some(child) = store.iter_children(iter) {
+                let filename = store.get_value(&child, Column::Filename as i32);
+                if filename.get::<&str>().is_none() {
+                    store.remove(&child);
+                    let dir_value = store.get_value(&iter, Column::Path as i32);
+                    if let Some(dir) = dir_value.get() {
+                        populate_tree_nodes(&store, &state, dir, Some(iter));
+                    }
+                }
+            }
+            Inhibit(false)
+        });
+
+        // Further initialization.
+        self.init_actions(&self.comps.context_menu);
+        self.init_subscriptions(shell_state);
+        self.connect_events();
+    }
+
+    fn init_actions(&self, menu: &gtk::Menu) {
+        let actions = gio::SimpleActionGroup::new();
+
+        let reload_action = gio::SimpleAction::new("reload", None);
+        let store = self.store.clone();
+        let state_ref = Rc::clone(&self.state);
+        reload_action.connect_activate(move |_, _| {
+            tree_reload(&store, &state_ref.borrow());
+        });
+        actions.add_action(&reload_action);
+
+        menu.insert_action_group("filebrowser", &actions);
+    }
+
+    fn init_subscriptions(&self, shell_state: &shell::State) {
+        // Always set the current working directory as the root of the file browser.
+        let store = self.store.clone();
+        let state_ref = Rc::clone(&self.state);
+        let go_up_btn = self.comps.go_up_btn.clone();
+        let cwd_label = self.comps.cwd_label.clone();
+        shell_state.subscribe("DirChanged", &["getcwd()"], move |args| {
+            let dir = args.into_iter().next().unwrap();
+            let mut state = state_ref.borrow_mut();
+            if dir != *state.current_dir {
+                update_toolbar(&dir, &go_up_btn, &cwd_label);
+                state.current_dir = dir;
+                tree_reload(&store, &state);
+            }
+        });
+
+        // Reveal the file of an entered buffer in the file browser and select the entry.
+        let tree = self.tree.clone();
+        let store = self.store.clone();
+        let subscription = shell_state
+            .subscribe("BufEnter", &["getcwd()", "expand('%:p')"], move |args: Vec<String>| {
+                let mut args_iter = args.into_iter();
+                let dir = args_iter.next().unwrap();
+                let file_path = args_iter.next().unwrap();
+                let could_reveal =
+                    if let Ok(rel_path) = Path::new(&file_path).strip_prefix(&Path::new(&dir)) {
+                        reveal_path_in_tree(&store, &tree, &rel_path)
+                    } else {
+                        false
+                    };
+                if !could_reveal{
+                    tree.get_selection().unselect_all();
+                }
+            });
+        shell_state.run_now(&subscription);
+    }
+
+    fn connect_events(&self) {
+        // Open file / go to dir, when user clicks on an entry.
+        let store = self.store.clone();
+        let nvim_ref = Rc::clone(&self.nvim.as_ref().unwrap());
+        self.tree.connect_row_activated(move |_, path, _| {
+            let mut nvim = nvim_ref.nvim().unwrap();
+            let iter = store.get_iter(path).unwrap();
+            let file_type = store
+                .get_value(&iter, Column::FileType as i32)
+                .get::<u8>()
+                .unwrap();
+            let file_path = store
+                .get_value(&iter, Column::Path as i32)
+                .get::<String>()
+                .unwrap();
+            if file_type == FileType::Dir as u8 {
+                nvim.set_current_dir(&file_path).report_err();
+            } else { // FileType::File
+                let dir = get_current_dir(&mut nvim);
+                let dir = Path::new(&dir);
+                let file_path = if let Some(rel_path) = Path::new(&file_path)
+                    .strip_prefix(&dir)
+                    .ok()
+                    .and_then(|p| p.to_str())
+                {
+                    rel_path
+                } else {
+                    &file_path
+                };
+                nvim.command(&format!(":e {}", file_path)).report_err();
+            }
+        });
+
+        // Connect go-up button.
+        let state_ref = Rc::clone(&self.state);
+        let nvim_ref = Rc::clone(&self.nvim.as_ref().unwrap());
+        self.comps.go_up_btn.connect_clicked(move |_| {
+            let dir = &state_ref.borrow().current_dir;
+            let parent = Path::new(&dir).parent().unwrap().to_str().unwrap();
+            let mut nvim = nvim_ref.nvim().unwrap();
+            nvim.set_current_dir(parent).report_err();
+        });
+
+        // Open context menu on right click.
+        let context_menu_ref = self.comps.context_menu.clone();
+        self.tree.connect_button_press_event(move |_, ev_btn| {
+            if ev_btn.get_button() == 3 {
+                context_menu_ref.popup_at_pointer(&**ev_btn);
+            }
+            Inhibit(false)
+        });
+
+        // Show / hide hidden files when corresponding menu item is toggled.
+        let state_ref = Rc::clone(&self.state);
+        let store = self.store.clone();
+        self.comps.show_hidden_checkbox.connect_toggled(move |ev| {
+            let mut state = state_ref.borrow_mut();
+            state.show_hidden = ev.get_active();
+            tree_reload(&store, &state);
+        });
+    }
+}
+
+/// Compare function for dir entries.
+///
+/// Sorts directories above files.
+fn cmp_dirs_first(lhs: &DirEntry, rhs: &DirEntry) -> io::Result<Ordering> {
+    let lhs_metadata = lhs.metadata()?;
+    let rhs_metadata = rhs.metadata()?;
+    if lhs_metadata.file_type() == rhs_metadata.file_type() {
+        Ok(lhs.path().cmp(&rhs.path()))
+    } else {
+        if lhs_metadata.is_dir() {
+            Ok(Ordering::Less)
+        } else {
+            Ok(Ordering::Greater)
+        }
+    }
+}
+
+/// Clears an repopulate the entire tree.
+fn tree_reload(store: &gtk::TreeStore, state: &State) {
+    let dir = &state.current_dir;
+    store.clear();
+    populate_tree_nodes(store, state, dir, None);
+}
+
+/// Updates the tool bar on top of the file browser.
+fn update_toolbar(dir: &str, go_up_btn: &gtk::Button, cwd_label: &gtk::Label) {
+    let path = Path::new(dir).canonicalize().unwrap();
+    // Disable go-up button if current directory is `/`.
+    go_up_btn.set_sensitive(path.parent().is_some());
+    // Display current directory name.
+    let dir_name = path.components().last().unwrap().as_os_str();
+    cwd_label.set_label(&*dir_name.to_string_lossy());
+}
+
+/// Populates one level, i.e. one directory of the file browser tree.
+fn populate_tree_nodes(
+    store: &gtk::TreeStore,
+    state: &State,
+    dir: &str,
+    parent: Option<&gtk::TreeIter>
+) {
+    let path = Path::new(dir);
+    let iter = path.read_dir()
+        .expect("read dir failed")
+        .filter_map(Result::ok);
+    let mut entries: Vec<DirEntry> = if state.show_hidden {
+        iter.collect()
+    } else {
+        iter.filter(|entry| !entry.file_name().to_string_lossy().starts_with("."))
+            .collect()
+    };
+    entries.sort_unstable_by(|lhs, rhs| {
+        cmp_dirs_first(lhs, rhs).unwrap_or(Ordering::Equal)
+    });
+    for entry in entries {
+        let path = if let Some(path) = entry.path().to_str() {
+            path.to_owned()
+        } else {
+            // Skip paths that contain invalid unicode.
+            continue;
+        };
+        let filename = entry.file_name().to_str().unwrap().to_owned();
+        let file_type = if let Ok(metadata) = fs::metadata(entry.path()) {
+            let file_type = metadata.file_type();
+            if file_type.is_dir() {
+                FileType::Dir
+            } else if file_type.is_file() {
+                FileType::File
+            } else {
+                continue;
+            }
+        } else {
+            // In case of invalid symlinks, we cannot obtain metadata.
+            continue;
+        };
+        let icon = match file_type {
+            FileType::Dir => "folder",
+            FileType::File => "text-x-generic",
+        };
+        // When we get until here, we want to show the entry. Append it to the tree.
+        let iter = store.append(parent);
+        store.set(&iter, &[0, 1, 2, 3], &[&filename, &path, &(file_type as u8), &icon]);
+        // For directories, check whether the directory is empty. If not, append a single empty
+        // entry, so the expand arrow is shown. Its contents are dynamically populated when
+        // expanded (see `init`).
+        if let FileType::Dir = file_type {
+            let not_empty = if let Ok(mut dir) = entry.path().read_dir() {
+                dir.next().is_some()
+            } else {
+                false
+            };
+            if not_empty {
+                let iter = store.append(&iter);
+                store.set(&iter, &[], &[]);
+            }
+        }
+    }
+}
+
+fn get_current_dir(nvim: &mut NeovimRef) -> String {
+    nvim.eval("getcwd()")
+        .as_ref()
+        .ok()
+        .and_then(|s| s.as_str())
+        .expect("Couldn't get working directory")
+        .to_owned()
+}
+
+/// Reveals and selects the given file in the file browser.
+///
+/// Returns `true` if the file could be successfully revealed.
+fn reveal_path_in_tree(
+    store: &gtk::TreeStore,
+    tree: &gtk::TreeView,
+    rel_file_path: &Path,
+) -> bool {
+    let mut tree_path = gtk::TreePath::new();
+    'components: for component in rel_file_path.components() {
+        if let Component::Normal(component) = component {
+            tree_path.down();
+            while let Some(iter) = store.get_iter(&tree_path) {
+                let entry_value = store.get_value(&iter, Column::Filename as i32);
+                let entry = entry_value.get::<&str>().unwrap();
+                if component == entry {
+                    tree.expand_row(&tree_path, false);
+                    continue 'components;
+                }
+                tree_path.next();
+            }
+            return false;
+        } else {
+            return false;
+        }
+    }
+    if tree_path.get_depth() == 0 {
+        return false;
+    }
+    tree.set_cursor(&tree_path, None, false);
+    true
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,6 +48,8 @@ mod popup_menu;
 mod project;
 mod tabline;
 mod error;
+mod file_browser;
+mod subscriptions;
 
 
 use std::env;

--- a/src/nvim/handler.rs
+++ b/src/nvim/handler.rs
@@ -83,6 +83,12 @@ impl NvimHandler {
                     error!("Unsupported event {:?}", params);
                 }
             }
+            "subscription" => {
+                self.safe_call(move |ui| {
+                    let ui = &ui.borrow();
+                    ui.notify(params)
+                });
+            }
             _ => {
                 error!("Notification {}({:?})", method, params);
             }
@@ -130,7 +136,7 @@ impl NvimHandler {
             }
         }
     }
- 
+
     fn safe_call<F>(&self, cb: F)
     where
         F: FnOnce(&Arc<UiMutex<shell::State>>) -> result::Result<(), String> + 'static + Send,

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -33,6 +33,7 @@ use error;
 use mode;
 use render;
 use render::CellMetrics;
+use subscriptions::{Subscriptions, SubscriptionHandle};
 
 const DEFAULT_FONT_NAME: &str = "DejaVu Sans Mono 12";
 pub const MINIMUM_SUPPORTED_NVIM_VERSION: &str = "0.2.1";
@@ -74,6 +75,8 @@ pub struct State {
 
     detach_cb: Option<Box<RefCell<FnMut() + Send + 'static>>>,
     nvim_started_cb: Option<Box<RefCell<FnMut() + Send + 'static>>>,
+
+    subscriptions: RefCell<Subscriptions>,
 }
 
 impl State {
@@ -108,6 +111,8 @@ impl State {
 
             detach_cb: None,
             nvim_started_cb: None,
+
+            subscriptions: RefCell::new(Subscriptions::new()),
         }
     }
 
@@ -296,6 +301,25 @@ impl State {
             };
 
         }
+    }
+
+    pub fn subscribe<F>(&self, event_name: &str, args: &[&str], cb: F) -> SubscriptionHandle
+    where
+        F: Fn(Vec<String>) + 'static,
+    {
+        self.subscriptions.borrow_mut().subscribe(event_name, args, cb)
+    }
+
+    pub fn set_autocmds(&self) {
+        self.subscriptions.borrow().set_autocmds(&mut self.nvim().unwrap());
+    }
+
+    pub fn notify(&self, params: Vec<Value>) -> Result<(), String> {
+        self.subscriptions.borrow().notify(params)
+    }
+
+    pub fn run_now(&self, handle: &SubscriptionHandle) {
+        self.subscriptions.borrow().run_now(handle, &mut self.nvim().unwrap());
     }
 }
 
@@ -539,6 +563,15 @@ impl Shell {
         let nvim = state.nvim();
         if let Some(mut nvim) = nvim {
             nvim.command(":wa").report_err();
+        }
+    }
+
+    pub fn new_tab(&self) {
+        let state = self.state.borrow();
+
+        let nvim = state.nvim();
+        if let Some(mut nvim) = nvim {
+            nvim.command(":tabe").report_err();
         }
     }
 

--- a/src/subscriptions.rs
+++ b/src/subscriptions.rs
@@ -1,0 +1,158 @@
+use std::collections::HashMap;
+
+use neovim_lib::{NeovimApi, Value};
+
+use nvim::NeovimRef;
+
+/// A subscription to a Neovim autocmd event.
+struct Subscription {
+    /// A callback to be executed each time the event triggers.
+    cb: Box<Fn(Vec<String>) + 'static>,
+    /// A list of expressions which will be evaluated when the event triggers. The result is passed
+    /// to the callback.
+    args: Vec<String>,
+}
+
+/// A map of all registered subscriptions.
+pub struct Subscriptions(HashMap<String, Vec<Subscription>>);
+
+/// A handle to identify a `Subscription` within the `Subscriptions` map.
+///
+/// Can be used to trigger the subscription manually even when the event was not triggered.
+///
+/// Could be used in the future to suspend individual subscriptions.
+#[derive(Debug)]
+pub struct SubscriptionHandle {
+    event_name: String,
+    index: usize,
+}
+
+impl Subscriptions {
+    pub fn new() -> Self {
+        Subscriptions(HashMap::new())
+    }
+
+    /// Subscribe to a Neovim autocmd event.
+    ///
+    /// Subscriptions are not active immediately but only after `set_autocmds` is called. At the
+    /// moment, all calls to `subscribe` must be made before calling `set_autocmds`.
+    ///
+    /// This function is wrapped by `shell::State`.
+    ///
+    /// # Arguments:
+    ///
+    /// - `event_name`: The event to register.
+    ///   See `:help autocmd-events` for a list of supported event names. Event names can be
+    ///   comma-separated.
+    ///
+    /// - `args`: A list of expressions to be evaluated when the event triggers.
+    ///   Expressions are evaluated using Vimscript. The results are passed to the callback as a
+    ///   list of Strings.
+    ///   This is especially useful as `Neovim::eval` is synchronous and might block if called from
+    ///   the callback function; so always use the `args` mechanism instead.
+    ///
+    /// - `cb`: The callback function.
+    ///   This will be called each time the event triggers or when `run_now` is called.
+    ///   It is passed a vector with the results of the evaluated expressions given with `args`.
+    ///
+    /// # Example
+    ///
+    /// Call a function each time a buffer is entered or the current working directory is changed.
+    /// Pass the current buffer name and directory to the callback.
+    /// ```
+    /// let my_subscription = shell.state.borrow()
+    ///     .subscribe("BufEnter,DirChanged", &["expand(@%)", "getcwd()"], move |args| {
+    ///         let filename = &args[0];
+    ///         let dir = &args[1];
+    ///         // do stuff
+    ///     });
+    /// ```
+    pub fn subscribe<F>(&mut self, event_name: &str, args: &[&str], cb: F) -> SubscriptionHandle
+    where
+        F: Fn(Vec<String>) + 'static,
+    {
+        let entry = self.0.entry(event_name.to_owned()).or_insert(Vec::new());
+        let index = entry.len();
+        entry.push(Subscription {
+            cb: Box::new(cb),
+            args: args.into_iter().map(|&s| s.to_owned()).collect(),
+        });
+        SubscriptionHandle {
+            event_name: event_name.to_owned(),
+            index,
+        }
+    }
+
+    /// Register all subscriptions with Neovim.
+    ///
+    /// This function is wrapped by `shell::State`.
+    pub fn set_autocmds(&self, nvim: &mut NeovimRef) {
+        for (event_name, subscriptions) in &self.0 {
+            for (i, subscription) in subscriptions.iter().enumerate() {
+                let args = subscription.args
+                    .iter()
+                    .fold("".to_owned(), |acc, arg| acc + ", " + &arg);
+                nvim.command(&format!(
+                    "au {} * call rpcnotify(1, 'subscription', '{}', {} {})",
+                    event_name,
+                    event_name,
+                    i,
+                    args,
+                )).expect("Could not set autocmd");
+            }
+        }
+    }
+
+    /// Trigger given event.
+    fn on_notify(&self, event_name: &str, index: usize, args: Vec<String>) {
+        if let Some(subscription) = self.0.get(event_name).and_then(|v| v.get(index)) {
+            (*subscription.cb)(args);
+        }
+    }
+
+    /// Wrapper around `on_notify` for easy calling with a `neovim_lib::Handler` implementation.
+    ///
+    /// This function is wrapped by `shell::State`.
+    pub fn notify(&self, params: Vec<Value>) -> Result<(), String> {
+        let mut params_iter = params.into_iter();
+        let ev_name = params_iter.next();
+        let ev_name = ev_name
+            .as_ref()
+            .and_then(Value::as_str)
+            .ok_or("Error reading event name")?;
+        let index = params_iter
+            .next()
+            .and_then(|i| i.as_u64())
+            .ok_or("Error reading index")? as usize;
+        let args = params_iter
+            .map(|arg| arg.as_str().map(|s| s.to_owned()))
+            .collect::<Option<Vec<String>>>()
+            .ok_or("Error reading args")?;
+        self.on_notify(ev_name, index, args);
+        Ok(())
+    }
+
+    /// Manually trigger the given subscription.
+    ///
+    /// The `nvim` instance is needed to evaluate the `args` expressions.
+    ///
+    /// This function is wrapped by `shell::State`.
+    pub fn run_now(&self, handle: &SubscriptionHandle, nvim: &mut NeovimRef) {
+        let subscription = &self.0.get(&handle.event_name).unwrap()[handle.index];
+        let args = subscription.args
+            .iter()
+            .map(|arg| nvim.eval(arg))
+            .map(|res| {
+                res.ok()
+                    .and_then(|val| {
+                        val.as_str().map(|s: &str| s.to_owned())
+                    })
+            })
+            .collect::<Option<Vec<String>>>();
+        if let Some(args) = args {
+            self.on_notify(&handle.event_name, handle.index, args);
+        } else {
+            error!("Error manually running {:?}", handle);
+        }
+    }
+}

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,12 +1,13 @@
 use std::cell::{RefCell, Ref, RefMut};
 use std::{env, thread};
+use std::path::Path;
 use std::rc::Rc;
 use std::sync::Arc;
 
 use gtk;
-use gtk_sys;
 use gtk::prelude::*;
-use gtk::{ApplicationWindow, HeaderBar, ToolButton, Image, AboutDialog, SettingsExt};
+use gtk::{ApplicationWindow, HeaderBar, Button, AboutDialog, SettingsExt, Paned, Orientation};
+use gio;
 use gio::prelude::*;
 use gio::{Menu, MenuExt, MenuItem, SimpleAction};
 
@@ -15,6 +16,8 @@ use shell::{Shell, ShellOptions};
 use shell_dlg;
 use project::Projects;
 use plug_manager;
+use file_browser::FileBrowserWidget;
+use subscriptions::SubscriptionHandle;
 
 macro_rules! clone {
     (@param _) => ( _ );
@@ -40,20 +43,27 @@ pub struct Ui {
     shell: Rc<RefCell<Shell>>,
     projects: Rc<RefCell<Projects>>,
     plug_manager: Arc<UiMutex<plug_manager::Manager>>,
+    file_browser: Arc<UiMutex<FileBrowserWidget>>,
 }
 
 pub struct Components {
     window: Option<ApplicationWindow>,
-    open_btn: ToolButton,
+    open_btn: Button,
 }
 
 impl Components {
     fn new() -> Components {
-        let save_image =
-            Image::new_from_icon_name("document-open", gtk_sys::GTK_ICON_SIZE_SMALL_TOOLBAR as i32);
-
+        let open_btn = Button::new();
+        let open_btn_box = gtk::Box::new(gtk::Orientation::Horizontal, 3);
+        open_btn_box.pack_start(&gtk::Label::new("Open"), false, false, 3);
+        open_btn_box.pack_start(
+            &gtk::Image::new_from_icon_name("pan-down-symbolic", gtk::IconSize::Menu.into()),
+            false, false, 3
+        );
+        open_btn.add(&open_btn_box);
+        open_btn.set_can_focus(false);
         Components {
-            open_btn: ToolButton::new(Some(&save_image), "Open"),
+            open_btn,
             window: None,
         }
     }
@@ -72,6 +82,7 @@ impl Ui {
         let plug_manager = plug_manager::Manager::new();
 
         let plug_manager = Arc::new(UiMutex::new(plug_manager));
+        let file_browser = Arc::new(UiMutex::new(FileBrowserWidget::new()));
         let comps = Arc::new(UiMutex::new(Components::new()));
         let settings = Rc::new(RefCell::new(Settings::new()));
         let shell = Rc::new(RefCell::new(Shell::new(settings.clone(), options)));
@@ -86,6 +97,7 @@ impl Ui {
             settings,
             projects,
             plug_manager,
+            file_browser,
         }
     }
 
@@ -98,11 +110,11 @@ impl Ui {
         let mut settings = self.settings.borrow_mut();
         settings.init();
 
-        let mut comps = self.comps.borrow_mut();
-
         self.shell.borrow_mut().init();
 
-        comps.window = Some(ApplicationWindow::new(app));
+        self.comps.borrow_mut().window = Some(ApplicationWindow::new(app));
+
+        let comps = self.comps.borrow();
         let window = comps.window.as_ref().unwrap();
 
         let prefer_dark_theme = env::var("NVIM_GTK_PREFER_DARK_THEME")
@@ -123,46 +135,57 @@ impl Ui {
             self.create_main_menu(app);
         }
 
-        if use_header_bar {
-            let header_bar = HeaderBar::new();
+        let update_subtitle = if use_header_bar {
+            Some(self.create_header_bar())
+        } else {
+            None
+        };
 
-            let projects = self.projects.clone();
-            header_bar.pack_start(&comps.open_btn);
-            comps.open_btn.connect_clicked(
-                move |_| projects.borrow_mut().show(),
-            );
+        let show_sidebar_action =
+            gio::SimpleAction::new_stateful("show-sidebar", None, &true.to_variant());
+        let file_browser_ref = self.file_browser.clone();
+        show_sidebar_action.connect_activate(move |action, _| {
+            if let Some(state) = action.get_state() {
+                let is_active = !state.get::<bool>().unwrap();
+                action.change_state(&(is_active).to_variant());
+                let file_browser = file_browser_ref.borrow();
+                file_browser.set_visible(is_active);
+            }
+        });
+        app.add_action(&show_sidebar_action);
 
-            let save_image = Image::new_from_icon_name(
-                "document-save",
-                gtk_sys::GTK_ICON_SIZE_SMALL_TOOLBAR as i32,
-            );
-            let save_btn = ToolButton::new(Some(&save_image), "Save");
+        window.set_default_size(1200, 800);
 
-            let shell = self.shell.clone();
-            save_btn.connect_clicked(move |_| shell.borrow_mut().edit_save_all());
-            header_bar.pack_start(&save_btn);
-
-            let paste_image = Image::new_from_icon_name(
-                "edit-paste",
-                gtk_sys::GTK_ICON_SIZE_SMALL_TOOLBAR as i32,
-            );
-            let paste_btn = ToolButton::new(Some(&paste_image), "Paste");
-            let shell = self.shell.clone();
-            paste_btn.connect_clicked(move |_| shell.borrow_mut().edit_paste());
-            header_bar.pack_start(&paste_btn);
-
-            header_bar.set_show_close_button(true);
-
-            window.set_titlebar(Some(&header_bar));
-        }
-
-        window.set_default_size(800, 600);
-
+        let main = Paned::new(Orientation::Horizontal);
         let shell = self.shell.borrow();
-        window.add(&**shell);
+        let file_browser = self.file_browser.borrow();
+        main.pack1(&**file_browser, false, false);
+        main.pack2(&**shell, true, false);
+
+        window.add(&main);
 
         window.show_all();
-        window.set_title("NeovimGtk");
+
+        let comps_ref = self.comps.clone();
+        let update_title = shell.state.borrow()
+            .subscribe("BufEnter,DirChanged", &["expand('%:p')", "getcwd()"], move |args| {
+                let comps = comps_ref.borrow();
+                let window = comps.window.as_ref().unwrap();
+                let file_path = &args[0];
+                let dir = Path::new(&args[1]);
+                let filename = if file_path.is_empty() {
+                    "[No Name]"
+                } else if let Some(rel_path) = Path::new(&file_path)
+                    .strip_prefix(&dir)
+                    .ok()
+                    .and_then(|p| p.to_str())
+                {
+                    rel_path
+                } else {
+                    &file_path
+                };
+                window.set_title(filename);
+            });
 
         let comps_ref = self.comps.clone();
         let shell_ref = self.shell.clone();
@@ -180,12 +203,73 @@ impl Ui {
         }));
 
         let state_ref = self.shell.borrow().state.clone();
+        let file_browser_ref = self.file_browser.clone();
         let plug_manager_ref = self.plug_manager.clone();
         shell.set_nvim_started_cb(Some(move || {
-            plug_manager_ref.borrow_mut().init_nvim_client(
-                state_ref.borrow().nvim_clone(),
-            );
+            let state = state_ref.borrow();
+            plug_manager_ref.borrow_mut().init_nvim_client(state.nvim_clone());
+            file_browser_ref.borrow_mut().init(&state);
+            state.set_autocmds();
+            state.run_now(&update_title);
+            if let Some(ref update_subtitle) = update_subtitle {
+                state.run_now(&update_subtitle);
+            }
         }));
+    }
+
+    fn create_header_bar(&self) -> SubscriptionHandle {
+        let header_bar = HeaderBar::new();
+        let shell = self.shell.borrow();
+        let comps = self.comps.borrow();
+        let window = comps.window.as_ref().unwrap();
+
+        let projects = self.projects.clone();
+        header_bar.pack_start(&comps.open_btn);
+        comps.open_btn.connect_clicked(
+            move |_| projects.borrow_mut().show(),
+        );
+
+        let new_tab_btn = Button::new_from_icon_name(
+            "tab-new-symbolic",
+            gtk::IconSize::SmallToolbar.into(),
+        );
+        let shell_ref = Rc::clone(&self.shell);
+        new_tab_btn.connect_clicked(move |_| shell_ref.borrow_mut().new_tab());
+        new_tab_btn.set_can_focus(false);
+        header_bar.pack_start(&new_tab_btn);
+
+        let builder = gtk::Builder::new_from_string(include_str!("../resources/menu.ui"));
+        let menu: gio::MenuModel = builder.get_object("hamburger-menu").unwrap();
+
+        let paste_action = gio::SimpleAction::new("paste", None);
+        let shell_ref = self.shell.clone();
+        paste_action.connect_activate(move |_, _| shell_ref.borrow_mut().edit_paste());
+        window.add_action(&paste_action);
+
+        let save_all_action = gio::SimpleAction::new("save-all", None);
+        let shell_ref = self.shell.clone();
+        save_all_action.connect_activate(move |_, _| shell_ref.borrow_mut().edit_save_all());
+        window.add_action(&save_all_action);
+
+        let menu_btn = gtk::MenuButton::new();
+        menu_btn.set_image(&gtk::Image::new_from_icon_name(
+            "open-menu-symbolic",
+            gtk::IconSize::SmallToolbar.into(),
+        ));
+        menu_btn.set_menu_model(&menu);
+        menu_btn.set_can_focus(false);
+        header_bar.pack_end(&menu_btn);
+
+        header_bar.set_show_close_button(true);
+
+        window.set_titlebar(Some(&header_bar));
+
+        let update_subtitle = shell.state.borrow()
+            .subscribe("DirChanged", &["getcwd()"], move |args| {
+                header_bar.set_subtitle(&*args[0]);
+            });
+
+        update_subtitle
     }
 
     fn create_main_menu(&self, app: &gtk::Application) {
@@ -196,6 +280,10 @@ impl Ui {
 
         let section = Menu::new();
         section.append_item(&MenuItem::new("New Window", "app.new-window"));
+        menu.append_section(None, &section);
+
+        let section = Menu::new();
+        section.append_item(&MenuItem::new("Sidebar", "app.show-sidebar"));
         menu.append_section(None, &section);
 
         let section = Menu::new();


### PR DESCRIPTION
This is more a request for comments than a final pull request.

I went and implemented a simple graphical file browser as a sidebar. Some of the other changes are related, but I also played around with some other things.

So my question is, what of this are you interested in, and what of that needs changing.

Other changes (mostly unrelated to the file browser):
- Header bar
    - Show current filename, working directory (related, as the new `subscriptions` module is used for this).
    - Rearrange buttons (closer match Gedit).
    - Add new-tab button.
- Projects popover
    - Use single click for activation.
    - Adapt the design to closer match Gedit.
- Tabline
    - Show close buttons on tabs (slightly related to new-tab button, as both actions can be done graphically now).

Of course, I could split parts of this to separate commits / pull requests, if wanted.