### PR TITLE
Use nvim.command_async where possible

### DIFF
--- a/src/plug_manager/vim_plug.rs
+++ b/src/plug_manager/vim_plug.rs
@@ -1,6 +1,6 @@
 use std::rc::Rc;
 
-use neovim_lib::NeovimApi;
+use neovim_lib::{NeovimApi, NeovimApiAsync};
 
 use nvim::{NeovimClient, ErrorReport, NeovimRef};
 use value::ValueMapExt;
@@ -84,7 +84,9 @@ impl Manager {
 
     pub fn reload(&self, path: &str) {
         if let Some(mut nvim) = self.nvim() {
-            nvim.command(&format!("source {}", path)).report_err();
+            nvim.command_async(&format!("source {}", path))
+                .cb(|r| r.report_err())
+                .call()
         }
     }
 }

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -184,13 +184,17 @@ impl State {
 
     pub fn open_file(&self, path: &str) {
         if let Some(mut nvim) = self.nvim() {
-            nvim.command(&format!("e {}", path)).report_err();
+            nvim.command_async(&format!("e {}", path))
+                .cb(|r| r.report_err())
+                .call();
         }
     }
 
     pub fn cd(&self, path: &str) {
         if let Some(mut nvim) = self.nvim() {
-            nvim.command(&format!("cd {}", path)).report_err();
+            nvim.command_async(&format!("cd {}", path))
+                .cb(|r| r.report_err())
+                .call();
         }
     }
 
@@ -600,7 +604,7 @@ impl Shell {
 
         let nvim = state.nvim();
         if let Some(mut nvim) = nvim {
-            nvim.command(":wa").report_err();
+            nvim.command_async(":wa").cb(|r| r.report_err()).call();
         }
     }
 
@@ -609,7 +613,7 @@ impl Shell {
 
         let nvim = state.nvim();
         if let Some(mut nvim) = nvim {
-            nvim.command(":tabe").report_err();
+            nvim.command_async(":tabe").cb(|r| r.report_err()).call();
         }
     }
 

--- a/src/subscriptions.rs
+++ b/src/subscriptions.rs
@@ -1,8 +1,8 @@
 use std::collections::HashMap;
 
-use neovim_lib::{NeovimApi, Value};
+use neovim_lib::{NeovimApi, NeovimApiAsync, Value};
 
-use nvim::NeovimRef;
+use nvim::{ErrorReport, NeovimRef};
 
 /// A subscription to a Neovim autocmd event.
 struct Subscription {
@@ -93,12 +93,11 @@ impl Subscriptions {
                     .args
                     .iter()
                     .fold("".to_owned(), |acc, arg| acc + ", " + &arg);
-                nvim.command(&format!(
+                nvim.command_async(&format!(
                     "au {} * call rpcnotify(1, 'subscription', '{}', {} {})",
                     event_name, event_name, i, args,
-                )).unwrap_or_else(|err| {
-                    error!("Could not set autocmd: {}", err);
-                });
+                )).cb(|r| r.report_err())
+                    .call();
             }
         }
     }

--- a/src/tabline.rs
+++ b/src/tabline.rs
@@ -10,7 +10,7 @@ use glib::signal;
 
 use pango;
 
-use neovim_lib::NeovimApi;
+use neovim_lib::{NeovimApi, NeovimApiAsync};
 use neovim_lib::neovim_api::Tabpage;
 
 use nvim;
@@ -42,7 +42,9 @@ impl State {
 
     fn close_tab(&self, idx: u32) {
         if let Some(mut nvim) = self.nvim.as_ref().unwrap().nvim() {
-            nvim.command(&format!(":tabc {}", idx + 1)).report_err();
+            nvim.command_async(&format!(":tabc {}", idx + 1))
+                .cb(|r| r.report_err())
+                .call();
         }
     }
 }


### PR DESCRIPTION
Pretty much what the title says.

The reason for my original problem turned out to be the call to `nvim.eval()` from `connect_row_activated()`, but I guess this doesn't hurt.

The problem I observed was a hang-up when calling `:ls` and then clicking an entry of the file tree without closing the output by hitting return first.