### PR TITLE
Fix bug where rapid `cd`s cause infinite loop

### DIFF
--- a/src/file_browser.rs
+++ b/src/file_browser.rs
@@ -180,7 +180,9 @@ impl FileBrowserWidget {
         cd_action.connect_activate(clone!(state_ref, nvim_ref => move |_, _| {
             let mut nvim = nvim_ref.nvim().unwrap();
             if let Some(ref path) = state_ref.borrow().selected_path {
-                nvim.set_current_dir(&path).report_err();
+                nvim.set_current_dir_async(&path)
+                    .cb(|r| r.report_err())
+                    .call();
             }
         }));
         actions.add_action(cd_action);
@@ -282,7 +284,9 @@ impl FileBrowserWidget {
                 if let Some(dir) = model.get_value(&iter, 2).get::<&str>() {
                     if dir != state_ref.borrow().current_dir {
                         let mut nvim = nvim_ref.nvim().unwrap();
-                        nvim.set_current_dir(dir).report_err();
+                        nvim.set_current_dir_async(dir)
+                            .cb(|r| r.report_err())
+                            .call();
                     }
                 }
             }

--- a/src/file_browser.rs
+++ b/src/file_browser.rs
@@ -201,11 +201,10 @@ impl FileBrowserWidget {
             &["getcwd()"],
             clone!(store, state_ref, dir_list_model, dir_list => move |args| {
                 let dir = args.into_iter().next().unwrap();
-                let mut state = state_ref.borrow_mut();
-                if dir != *state.current_dir {
+                if dir != state_ref.borrow().current_dir {
+                    state_ref.borrow_mut().current_dir = dir.to_owned();
                     update_dir_list(&dir, &dir_list_model, &dir_list);
-                    state.current_dir = dir;
-                    tree_reload(&store, &state);
+                    tree_reload(&store, &state_ref.borrow());
                 }
             }),
         );
@@ -277,18 +276,18 @@ impl FileBrowserWidget {
 
         // Connect directory list.
         let nvim_ref = self.nvim.as_ref().unwrap();
-        self.comps.dir_list.connect_changed(clone!(nvim_ref => move |dir_list| {
+        self.comps.dir_list.connect_changed(clone!(nvim_ref, state_ref => move |dir_list| {
             if let Some(iter) = dir_list.get_active_iter() {
                 let model = dir_list.get_model().unwrap();
                 if let Some(dir) = model.get_value(&iter, 2).get::<&str>() {
-                    let mut nvim = nvim_ref.nvim().unwrap();
-                    nvim.set_current_dir(dir).report_err();
+                    if dir != state_ref.borrow().current_dir {
+                        let mut nvim = nvim_ref.nvim().unwrap();
+                        nvim.set_current_dir(dir).report_err();
+                    }
                 }
             }
         }));
 
-        let store = &self.store;
-        let state_ref = &self.state;
         let context_menu = &self.comps.context_menu;
         let cd_action = &self.comps.cd_action;
         self.tree.connect_button_press_event(


### PR DESCRIPTION
The directory chooser on top of the file tree had a bug where it would trigger another directory change for each directory change. When directories are changed quickly, e.g. by a plugin or fast scrolling on top of the directory chooser, this triggers an infinite loop, resulting in a lockup of the application.