### PR TITLE
Use `error!`/`warn!` logs instead of `println!`

### DIFF
--- a/src/project.rs
+++ b/src/project.rs
@@ -439,7 +439,7 @@ impl EntryStore {
                         entries.insert(0, Entry::new_current_project(pwd));
                     }
                 } else {
-                    println!("Error get current directory");
+                    error!("Error get current directory");
                 }
             }
             err @ Err(_) => err.report_err(),

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -122,7 +122,7 @@ pub trait SettingsLoader: Sized + serde::Serialize {
         match load_err() {
             Ok(settings) => settings,
             Err(e) => {
-                println!("{}", e);
+                error!("{}", e);
                 Self::empty()
             }
         }

--- a/src/shell_dlg.rs
+++ b/src/shell_dlg.rs
@@ -18,7 +18,7 @@ pub fn can_close_window(comps: &UiMutex<Components>, shell: &RefCell<Shell>) -> 
             }
         }
         Err(ref err) => {
-            println!("Error getting info from nvim: {}", err);
+            error!("Error getting info from nvim: {}", err);
             true
         }
     }
@@ -58,7 +58,7 @@ fn show_not_saved_dlg(comps: &UiMutex<Components>, shell: &Shell, changed_bufs: 
             let mut nvim = state.nvim().unwrap();
             match nvim.command("wa") {
                 Err(ref err) => {
-                    println!("Error: {}", err);
+                    error!("Error: {}", err);
                     false
                 }
                 _ => true,
@@ -87,11 +87,11 @@ fn get_changed_buffers(shell: &Shell) -> Result<Vec<String>, CallError> {
                         match buf.get_option(&mut nvim, "modified") {
                             Ok(Value::Boolean(val)) => val,
                             Ok(_) => {
-                                println!("Value must be boolean");
+                                warn!("Value must be boolean");
                                 false
                             }
                             Err(ref err) => {
-                                println!(
+                                error!(
                                     "Something going wrong while getting buffer option: {}",
                                     err
                                 );
@@ -101,7 +101,7 @@ fn get_changed_buffers(shell: &Shell) -> Result<Vec<String>, CallError> {
                         match buf.get_name(&mut nvim) {
                             Ok(name) => name,
                             Err(ref err) => {
-                                println!(
+                                error!(
                                     "Something going wrong while getting buffer name: {}",
                                     err
                                 );


### PR DESCRIPTION
Writing to `stdout` will panic if the pipe is broken. This can happen, for example, if you run (in Linux):
```sh
nvim-gtk & exit
```

Then repeatedly hit `<Tab>`  to make it print `Event bell([])` to the (already closed) `STDOUT`. After a few tabs it'll crash - because it is trying to write to a broken pipe.

The macros from the `log` crate don't crash when the pipe is broken. It also makes more sense to use them, since these prints are not the actual _output_ of the application.