### PR TITLE
Pass arguments after `--` directly to Neovim

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -103,14 +103,17 @@ fn main() {
 
     gtk::Window::set_default_icon_name("org.daa.NeovimGtk");
 
-    let args: Vec<String> = env::args().collect();
-    let argv: Vec<String> = args.iter()
+    let argv: Vec<String> = env::args()
+        .take_while(|a| *a != "--")
         .filter(|a| !a.starts_with(BIN_PATH_ARG))
         .filter(|a| !a.starts_with(TIMEOUT_ARG))
         .filter(|a| !a.starts_with(DISABLE_WIN_STATE_RESTORE))
-        .cloned()
         .collect();
     app.run(&argv);
+}
+
+fn collect_args_for_nvim() -> Vec<String> {
+    std::env::args().skip_while(|a| *a != "--").skip(1).collect()
 }
 
 fn open(app: &gtk::Application, files: &[gio::File], _: &str) {
@@ -122,6 +125,7 @@ fn open(app: &gtk::Application, files: &[gio::File], _: &str) {
         nvim_bin_path(std::env::args()),
         files_list,
         nvim_timeout(std::env::args()),
+        collect_args_for_nvim(),
         None,
     ));
 
@@ -133,6 +137,7 @@ fn activate(app: &gtk::Application, input_data: Option<String>) {
         nvim_bin_path(std::env::args()),
         Vec::new(),
         nvim_timeout(std::env::args()),
+        collect_args_for_nvim(),
         input_data,
     ));
 

--- a/src/nvim/mod.rs
+++ b/src/nvim/mod.rs
@@ -84,6 +84,7 @@ pub fn start(
     handler: NvimHandler,
     nvim_bin_path: Option<&String>,
     timeout: Option<Duration>,
+    args_for_neovim: Vec<String>,
 ) -> result::Result<Neovim, NvimInitError> {
     let mut cmd = if let Some(path) = nvim_bin_path {
         Command::new(path)
@@ -118,6 +119,10 @@ pub fn start(
         if let Some(path) = nvim_config.to_str() {
             cmd.arg("--cmd").arg(format!("source {}", path));
         }
+    }
+
+    for arg in args_for_neovim {
+        cmd.arg(arg);
     }
 
     let session = Session::new_child_cmd(&mut cmd);

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -530,6 +530,7 @@ pub struct ShellOptions {
     nvim_bin_path: Option<String>,
     open_paths: Vec<String>,
     timeout: Option<Duration>,
+    args_for_neovim: Vec<String>,
     input_data: Option<String>,
 }
 
@@ -538,12 +539,14 @@ impl ShellOptions {
         nvim_bin_path: Option<String>,
         open_paths: Vec<String>,
         timeout: Option<Duration>,
+        args_for_neovim: Vec<String>,
         input_data: Option<String>,
     ) -> Self {
         ShellOptions {
             nvim_bin_path,
             open_paths,
             timeout,
+            args_for_neovim,
             input_data,
         }
     }
@@ -1093,6 +1096,7 @@ fn init_nvim_async(
         nvim_handler,
         options.nvim_bin_path.as_ref(),
         options.timeout,
+        options.args_for_neovim,
     ) {
         Ok(nvim) => nvim,
         Err(err) => {


### PR DESCRIPTION
This allows some more advanced workflows, such as:

* Run with the default configuration:
    ```bash
    nvim-gtk -- -u NONE
    ```
* Diff between two files:
    ```bash
    nvim-gtk -- -d file1 file2
    ```
* Run commands:
    ```bash
    nvim-gtk -- -s speacial_preparations.vim
    ```
And more.