### PR TITLE
Mention the Debian/Ubuntu GTK dev packages in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,14 @@ Windows binaries on appveyor
 
 # Build
 ## Linux
-Install GTK development packages. Install latest rust compiler, better use *rustup* tool. Build command:
+Firstly, install the GTK development packages. On Debian/Ubuntu derivatives
+this can be done as follows:
+```
+apt install libatk1.0-dev libcairo2-dev libgdk-pixbuf2.0-dev libglib2.0-dev libgtk-3-dev libpango1.0-dev
+```
+
+Then install the latest rust compiler, best done with the
+[rustup tool](https://rustup.rs/). The build command:
 ```
 cargo build --release
 ```


### PR DESCRIPTION
I had to discover the exact packages to install when trying this project out, so I thought I'd document them in the README.

Adding an equivalent section for Red Hat-derived distributions too sounds like a good idea, perhaps in a future PR.