### PR TITLE
Add patterns to event subscriptions and test with settable title prefix

### DIFF
--- a/src/file_browser.rs
+++ b/src/file_browser.rs
@@ -18,6 +18,7 @@ use neovim_lib::{NeovimApi, NeovimApiAsync};
 use misc::escape_filename;
 use nvim::{ErrorReport, NeovimClient, NeovimRef};
 use shell;
+use subscriptions::SubscriptionKey;
 
 const ICON_FOLDER_CLOSED: &str = "folder-symbolic";
 const ICON_FOLDER_OPEN: &str = "folder-open-symbolic";
@@ -199,7 +200,7 @@ impl FileBrowserWidget {
         let dir_list_model = &self.comps.dir_list_model;
         let dir_list = &self.comps.dir_list;
         shell_state.subscribe(
-            "DirChanged",
+            SubscriptionKey::from("DirChanged"),
             &["getcwd()"],
             clone!(store, state_ref, dir_list_model, dir_list => move |args| {
                 let dir = args.into_iter().next().unwrap();
@@ -214,7 +215,7 @@ impl FileBrowserWidget {
         // Reveal the file of an entered buffer in the file browser and select the entry.
         let tree = &self.tree;
         let subscription = shell_state.subscribe(
-            "BufEnter",
+            SubscriptionKey::from("BufEnter"),
             &["getcwd()", "expand('%:p')"],
             clone!(tree, store => move |args| {
                 let mut args_iter = args.into_iter();

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -38,7 +38,7 @@ use mode;
 use popup_menu::{self, PopupMenu};
 use render;
 use render::CellMetrics;
-use subscriptions::{SubscriptionHandle, Subscriptions};
+use subscriptions::{SubscriptionHandle, SubscriptionKey, Subscriptions};
 use tabline::Tabline;
 use ui::UiMutex;
 
@@ -493,13 +493,13 @@ impl State {
         self.drawing_area.get_allocated_width() - 20
     }
 
-    pub fn subscribe<F>(&self, event_name: &str, args: &[&str], cb: F) -> SubscriptionHandle
+    pub fn subscribe<F>(&self, key: SubscriptionKey, args: &[&str], cb: F) -> SubscriptionHandle
     where
         F: Fn(Vec<String>) + 'static,
     {
         self.subscriptions
             .borrow_mut()
-            .subscribe(event_name, args, cb)
+            .subscribe(key, args, cb)
     }
 
     pub fn set_autocmds(&self) {

--- a/src/subscriptions.rs
+++ b/src/subscriptions.rs
@@ -13,8 +13,36 @@ struct Subscription {
     args: Vec<String>,
 }
 
+/// Subscription keys represent a NeoVim event coupled with a matching pattern. It is expected for
+/// the pattern more often than not to be `"*"`.
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct SubscriptionKey {
+    event_name: String,
+    pattern: String,
+}
+
+impl<'a> From<&'a str> for SubscriptionKey {
+
+    fn from(event_name: &'a str) -> Self {
+        SubscriptionKey {
+            event_name: event_name.to_owned(),
+            pattern: "*".to_owned(),
+        }
+    }
+}
+
+impl SubscriptionKey {
+
+    pub fn with_pattern(event_name: &str, pattern: &str) -> Self {
+        SubscriptionKey {
+            event_name: event_name.to_owned(),
+            pattern: pattern.to_owned(),
+        }
+    }
+}
+
 /// A map of all registered subscriptions.
-pub struct Subscriptions(HashMap<String, Vec<Subscription>>);
+pub struct Subscriptions(HashMap<SubscriptionKey, Vec<Subscription>>);
 
 /// A handle to identify a `Subscription` within the `Subscriptions` map.
 ///
@@ -23,7 +51,7 @@ pub struct Subscriptions(HashMap<String, Vec<Subscription>>);
 /// Could be used in the future to suspend individual subscriptions.
 #[derive(Debug)]
 pub struct SubscriptionHandle {
-    event_name: String,
+    key: SubscriptionKey,
     index: usize,
 }
 
@@ -41,7 +69,7 @@ impl Subscriptions {
     ///
     /// # Arguments:
     ///
-    /// - `event_name`: The event to register.
+    /// - `key`: The subscription key to register.
     ///   See `:help autocmd-events` for a list of supported event names. Event names can be
     ///   comma-separated.
     ///
@@ -67,18 +95,18 @@ impl Subscriptions {
     ///         // do stuff
     ///     });
     /// ```
-    pub fn subscribe<F>(&mut self, event_name: &str, args: &[&str], cb: F) -> SubscriptionHandle
+    pub fn subscribe<F>(&mut self, key: SubscriptionKey, args: &[&str], cb: F) -> SubscriptionHandle
     where
         F: Fn(Vec<String>) + 'static,
     {
-        let entry = self.0.entry(event_name.to_owned()).or_insert(Vec::new());
+        let entry = self.0.entry(key.clone()).or_insert(Vec::new());
         let index = entry.len();
         entry.push(Subscription {
             cb: Box::new(cb),
             args: args.into_iter().map(|&s| s.to_owned()).collect(),
         });
         SubscriptionHandle {
-            event_name: event_name.to_owned(),
+            key,
             index,
         }
     }
@@ -87,24 +115,26 @@ impl Subscriptions {
     ///
     /// This function is wrapped by `shell::State`.
     pub fn set_autocmds(&self, nvim: &mut NeovimRef) {
-        for (event_name, subscriptions) in &self.0 {
+        for (key, subscriptions) in &self.0 {
+            let SubscriptionKey { event_name, pattern } = key;
             for (i, subscription) in subscriptions.iter().enumerate() {
                 let args = subscription
                     .args
                     .iter()
                     .fold("".to_owned(), |acc, arg| acc + ", " + &arg);
-                nvim.command_async(&format!(
-                    "au {} * call rpcnotify(1, 'subscription', '{}', {} {})",
-                    event_name, event_name, i, args,
-                )).cb(|r| r.report_err())
+                let autocmd = format!(
+                    "autocmd {} {} call rpcnotify(1, 'subscription', '{}', '{}', {} {})",
+                    event_name, pattern, event_name, pattern, i, args,
+                );
+                nvim.command_async(&autocmd).cb(|r| r.report_err())
                     .call();
             }
         }
     }
 
     /// Trigger given event.
-    fn on_notify(&self, event_name: &str, index: usize, args: Vec<String>) {
-        if let Some(subscription) = self.0.get(event_name).and_then(|v| v.get(index)) {
+    fn on_notify(&self, key: &SubscriptionKey, index: usize, args: Vec<String>) {
+        if let Some(subscription) = self.0.get(key).and_then(|v| v.get(index)) {
             (*subscription.cb)(args);
         }
     }
@@ -119,15 +149,29 @@ impl Subscriptions {
             .as_ref()
             .and_then(Value::as_str)
             .ok_or("Error reading event name")?;
+        let pattern = params_iter.next();
+        let pattern = pattern
+            .as_ref()
+            .and_then(Value::as_str)
+            .ok_or("Error reading pattern")?;
+        let key = SubscriptionKey {
+            event_name: String::from(ev_name),
+            pattern: String::from(pattern)
+        };
         let index = params_iter
             .next()
             .and_then(|i| i.as_u64())
             .ok_or("Error reading index")? as usize;
         let args = params_iter
-            .map(|arg| arg.as_str().map(|s| s.to_owned()))
+            .map(|arg| {
+                arg
+                    .as_str()
+                    .map(|s: &str| s.to_owned())
+                    .or_else(|| arg.as_u64().map(|uint: u64| format!("{}", uint)))
+            })
             .collect::<Option<Vec<String>>>()
             .ok_or("Error reading args")?;
-        self.on_notify(ev_name, index, args);
+        self.on_notify(&key, index, args);
         Ok(())
     }
 
@@ -137,18 +181,23 @@ impl Subscriptions {
     ///
     /// This function is wrapped by `shell::State`.
     pub fn run_now(&self, handle: &SubscriptionHandle, nvim: &mut NeovimRef) {
-        let subscription = &self.0.get(&handle.event_name).unwrap()[handle.index];
+        let subscription = &self.0.get(&handle.key).unwrap()[handle.index];
         let args = subscription
             .args
             .iter()
             .map(|arg| nvim.eval(arg))
             .map(|res| {
                 res.ok()
-                    .and_then(|val| val.as_str().map(|s: &str| s.to_owned()))
+                    .and_then(|val| {
+                        val
+                            .as_str()
+                            .map(|s: &str| s.to_owned())
+                            .or_else(|| val.as_u64().map(|uint: u64| format!("{}", uint)))
+                    })
             })
             .collect::<Option<Vec<String>>>();
         if let Some(args) = args {
-            self.on_notify(&handle.event_name, handle.index, args);
+            self.on_notify(&handle.key, handle.index, args);
         } else {
             error!("Error manually running {:?}", handle);
         }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -230,21 +230,21 @@ impl Ui {
         let comps_ref = self.comps.clone();
         let update_title = shell.state.borrow().subscribe(
             SubscriptionKey::from("BufEnter,DirChanged"),
-            &["&title", "&titlestring", "expand('%:p')", "getcwd()"],
+            &["&title", "expand(&titlestring)", "expand('%:p')", "getcwd()"],
             move |args| update_window_title(&comps_ref, args),
         );
 
         let comps_ref = self.comps.clone();
         shell.state.borrow().subscribe(
             SubscriptionKey::with_pattern("OptionSet", "titlestring"),
-            &["&title", "&titlestring", "expand('%:p')", "getcwd()"],
+            &["&title", "expand(&titlestring)", "expand('%:p')", "getcwd()"],
             move |args| update_window_title(&comps_ref, args),
         );
 
         let comps_ref = self.comps.clone();
         shell.state.borrow().subscribe(
             SubscriptionKey::with_pattern("OptionSet", "title"),
-            &["&title", "&titlestring", "expand('%:p')", "getcwd()"],
+            &["&title", "expand(&titlestring)", "expand('%:p')", "getcwd()"],
             move |args| update_window_title(&comps_ref, args),
         );
 
@@ -456,30 +456,29 @@ fn gtk_window_state_event(event: &gdk::EventWindowState, comps: &mut Components)
 
 fn update_window_title(comps: &Arc<UiMutex<Components>>, args: Vec<String>) {
     let titles_enabled = &args[0];
-    let new_title_prefix = &args[1];
+    let new_title = &args[1];
     let comps_ref = comps.clone();
     let comps = comps_ref.borrow();
     let window = comps.window.as_ref().unwrap();
 
-    let file_path = &args[2];
-    let dir = Path::new(&args[3]);
-    let filename = if file_path.is_empty() {
-        "[No Name]"
-    } else if let Some(rel_path) = Path::new(&file_path)
-        .strip_prefix(&dir)
-        .ok()
-        .and_then(|p| p.to_str())
-    {
-        rel_path
-    } else {
-        &file_path
-    };
+    if (titles_enabled == "0") || new_title.is_empty() {
+        let file_path = &args[2];
+        let dir = Path::new(&args[3]);
+        let filename = if file_path.is_empty() {
+            "[No Name]"
+        } else if let Some(rel_path) = Path::new(&file_path)
+            .strip_prefix(&dir)
+            .ok()
+            .and_then(|p| p.to_str())
+        {
+            rel_path
+        } else {
+            &file_path
+        };
 
-    if (titles_enabled == "0") || new_title_prefix.is_empty() {
         window.set_title(filename);
     } else {
-        let title = format!("{} - {}", new_title_prefix, filename);
-        window.set_title(&title);
+        window.set_title(&new_title);
     }
 }
 


### PR DESCRIPTION
Events were subscribed and keyed with their event name; now the combination of the event name and a matching pattern is used instead. This allows `Subscriptions#subscribe` to be used with patterns too.

A real world use case for this is addressing issue #39, which this PR does as a test case.