### PR TITLE
[RFC] unset decorated flag when NVIM_GTK_NO_HEADERBAR=1

### DIFF
--- a/src/ui.rs
+++ b/src/ui.rs
@@ -167,6 +167,10 @@ impl Ui {
             .map(|opt| opt.trim() != "1")
             .unwrap_or(true);
 
+        if !use_header_bar {
+            window.set_decorated(false);
+        }
+
         if app.prefers_app_menu() || use_header_bar {
             self.create_main_menu(app, &window);
         }


### PR DESCRIPTION
This is actually a small change and ensures that there are no decorations when headerbar is disabled. Is this the intended behavior? Or maybe this should be a different option altogether?