### PR TITLE
Make installation repsect DESTDIR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,21 +7,21 @@ run:
 	RUST_BACKTRACE=1 cargo run -- --no-fork
 
 install: install-resources
-	cargo install --force --root $(PREFIX)
+	cargo install --force --root $(DESTDIR)$(PREFIX)
 
 install-debug: install-resources
-	cargo install --debug --force --root $(PREFIX)
+	cargo install --debug --force --root $(DESTDIR)$(PREFIX)
 
 install-resources:
-	mkdir -p $(PREFIX)/share/nvim-gtk/
-	cp -r runtime $(PREFIX)/share/nvim-gtk/ 
-	mkdir -p $(PREFIX)/share/applications/
-	cp desktop/org.daa.NeovimGtk.desktop $(PREFIX)/share/applications/
-	sed -i "s|Exec=nvim-gtk|Exec=$(PREFIX)/bin/nvim-gtk|" $(PREFIX)/share/applications/org.daa.NeovimGtk.desktop
-	mkdir -p $(PREFIX)/share/icons/hicolor/48x48/apps/
-	cp desktop/org.daa.NeovimGtk.png $(PREFIX)/share/icons/hicolor/48x48/apps/
-	mkdir -p $(PREFIX)/share/icons/hicolor/scalable/apps/
-	cp desktop/org.daa.NeovimGtk.svg $(PREFIX)/share/icons/hicolor/scalable/apps/
-	mkdir -p $(PREFIX)/share/fonts/
-	cp -n desktop/dejavu_font/*.ttf $(PREFIX)/share/fonts/
+	mkdir -p $(DESTDIR)$(PREFIX)/share/nvim-gtk/
+	cp -r runtime $(DESTDIR)$(PREFIX)/share/nvim-gtk/
+	mkdir -p $(DESTDIR)$(PREFIX)/share/applications/
+	cp desktop/org.daa.NeovimGtk.desktop $(DESTDIR)$(PREFIX)/share/applications/
+	sed -i "s|Exec=nvim-gtk|Exec=$(PREFIX)/bin/nvim-gtk|" $(DESTDIR)$(PREFIX)/share/applications/org.daa.NeovimGtk.desktop
+	mkdir -p $(DESTDIR)$(PREFIX)/share/icons/hicolor/48x48/apps/
+	cp desktop/org.daa.NeovimGtk.png $(DESTDIR)$(PREFIX)/share/icons/hicolor/48x48/apps/
+	mkdir -p $(DESTDIR)$(PREFIX)/share/icons/hicolor/scalable/apps/
+	cp desktop/org.daa.NeovimGtk.svg $(DESTDIR)$(PREFIX)/share/icons/hicolor/scalable/apps/
+	mkdir -p $(DESTDIR)$(PREFIX)/share/fonts/
+	cp -n desktop/dejavu_font/*.ttf $(DESTDIR)$(PREFIX)/share/fonts/
 	fc-cache -fv


### PR DESCRIPTION
The DESTDIR variable is usually set when a piece of software is being
packaged. It tells the installation script that it should place its
files to a specific directory while not affecting PREFIX.