### PR TITLE
Don't use -i option for sed to make it more compatible with non-GNU sed.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,9 @@ install-resources:
 	mkdir -p $(DESTDIR)$(PREFIX)/share/nvim-gtk/
 	cp -r runtime $(DESTDIR)$(PREFIX)/share/nvim-gtk/
 	mkdir -p $(DESTDIR)$(PREFIX)/share/applications/
-	cp desktop/org.daa.NeovimGtk.desktop $(DESTDIR)$(PREFIX)/share/applications/
-	sed -i "s|Exec=nvim-gtk|Exec=$(PREFIX)/bin/nvim-gtk|" $(DESTDIR)$(PREFIX)/share/applications/org.daa.NeovimGtk.desktop
+	sed -e "s|Exec=nvim-gtk|Exec=$(PREFIX)/bin/nvim-gtk|" \
+		desktop/org.daa.NeovimGtk.desktop \
+		>$(DESTDIR)$(PREFIX)/share/applications/org.daa.NeovimGtk.desktop
 	mkdir -p $(DESTDIR)$(PREFIX)/share/icons/hicolor/128x128/apps/
 	cp desktop/org.daa.NeovimGtk_128.png $(DESTDIR)$(PREFIX)/share/icons/hicolor/128x128/apps/org.daa.NeovimGtk.png
 	mkdir -p $(DESTDIR)$(PREFIX)/share/icons/hicolor/48x48/apps/
@@ -26,6 +27,5 @@ install-resources:
 	cp desktop/org.daa.NeovimGtk.svg $(DESTDIR)$(PREFIX)/share/icons/hicolor/scalable/apps/
 	mkdir -p $(DESTDIR)$(PREFIX)/share/icons/hicolor/symbolic/apps/
 	cp desktop/org.daa.NeovimGtk-symbolic.svg $(DESTDIR)$(PREFIX)/share/icons/hicolor/symbolic/apps/
-	mkdir -p $(DESTDIR)$(PREFIX)/share/fonts/
-	cp -n desktop/dejavu_font/*.ttf $(DESTDIR)$(PREFIX)/share/fonts/
-	fc-cache -fv
+
+.PHONY: all clean test


### PR DESCRIPTION
Also, add missing .PHONY target.
Also, in my opinion a text editor has no business to install fonts to my system. If we require a font, then we should say so in README, or raise an error when it is missing, but not install it on our own.

Fixes #164