### PR TITLE
Expand tabs to fill tabline

### DIFF
--- a/src/tabline.rs
+++ b/src/tabline.rs
@@ -135,6 +135,7 @@ impl Tabline {
                 title.show();
                 close_btn.show();
                 self.tabs.append_page(&empty, Some(&label_box));
+                self.tabs.set_child_tab_expand(&empty, true);
 
                 let tabs = self.tabs.clone();
                 let state_ref = Rc::clone(&self.state);


### PR DESCRIPTION
More of an aesthetic improvement. But pretty much all Gnome apps do this, so I guess this PR improves HIG compliance.