### PR TITLE
Adds an option to change cursor blinking

### DIFF
--- a/runtime/plugin/nvim_gui_shim.vim
+++ b/runtime/plugin/nvim_gui_shim.vim
@@ -62,4 +62,5 @@ command! NGToggleSidebar call rpcnotify(1, 'Gui', 'Command', 'ToggleSidebar')
 command! NGShowProjectView call rpcnotify(1, 'Gui', 'Command', 'ShowProjectView')
 command! -nargs=+ NGTransparency call rpcnotify(1, 'Gui', 'Command', 'Transparency', <f-args>)
 command! -nargs=1 NGPreferDarkTheme call rpcnotify(1, 'Gui', 'Command', 'PreferDarkTheme', <q-args>)
+command! -nargs=1 NGSetCursorBlink call rpcnotify(1, 'Gui', 'Command', 'SetCursorBlink', <q-args>)
 

--- a/src/nvim/redraw_handler.rs
+++ b/src/nvim/redraw_handler.rs
@@ -182,6 +182,16 @@ pub fn call_gui_event(
 
                     ui.on_command(NvimCommand::PreferDarkTheme(prefer_dark_theme))
                 }
+                "SetCursorBlink" => {
+                    let blink_count =
+                        match try_str!(args.get(1).cloned().unwrap_or_else(|| Value::from(-1)))
+                            .parse::<i32>()
+                        {
+                            Ok(val) => val,
+                            Err(_) => -1,
+                        };
+                    ui.set_cursor_blink(blink_count);
+                }
                 _ => error!("Unknown command"),
             };
         }

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -317,6 +317,12 @@ impl State {
         self.transparency_settings.enabled
     }
 
+    pub fn set_cursor_blink(&mut self, val: i32) {
+        if let Some(cursor) = &mut self.cursor {
+            cursor.set_cursor_blink(val);
+        }
+    }
+
     pub fn open_file(&self, path: &str) {
         if let Some(mut nvim) = self.nvim() {
             nvim.command_async(&format!("e {}", path))


### PR DESCRIPTION
`:NGSetCursorBlink` can set the number of times the cursor blinks before stopping or disable the cursor blinking entirely. If the value passed in is negative, the cursor won't stop blinking, and if it's zero, the cursor won't blink.

I'm a newbie at both Rust and Vim, so I'm not sure if this is the best way of implementing the option. Thanks!!