### PR TITLE
Handle CJK rendering

### DIFF
--- a/src/render/context.rs
+++ b/src/render/context.rs
@@ -87,7 +87,9 @@ struct FontMetrix {
 
 impl FontMetrix {
     pub fn new(pango_context: pango::Context, line_space: i32) -> Self {
-        let font_metrics = pango_context.get_metrics(None, None).unwrap();
+        let font_metrics = pango_context
+            .get_metrics(None, Some(&pango::Language::from_string("en_US")))
+            .unwrap();
         let font_desc = pango_context.get_font_description().unwrap();
 
         FontMetrix {


### PR DESCRIPTION
This changeset addresses two problems:

1. When language is set to zh_TW (`LANG=zh_TW`), the metrics would be incorrect.
2. When rendering CJK characters, the width of each consecutive CJK characters would be off.

This changeset addresses the above problems by making a break in itemizer for every non-ascii characters, as well as forcing the metrics information to be in `en_US`.  This assumes that monospace fonts have all ASCII glyphs.  Also, this would cause ligatures in non-ASCII fail.

Closes #256 